### PR TITLE
Fetch latest 2.y.z Spark versions for dynamic concurrent builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,13 +72,13 @@ script:
     grep -oE '[2]\.[[:digit:]]+\.[[:digit:]]' |
     sort | uniq |
     awk "NR % ${N} == ${IDX}")
-- echo Spark version\(s\) to build ~ ${SPARK_VERSIONS_RAW}
+- echo Spark version\(s\) to build - ${SPARK_VERSIONS_RAW}
 - declare -a SPARK_VERSIONS=(${SPARK_VERSIONS_RAW})
 
 # Iterate across each Spark version
 - |-
   for SPARK_VERSION in "${SPARK_VERSIONS[@]}"; do
-    echo Building Spark version ~ ${SPARK_VERSION}
+    echo Building Spark version - ${SPARK_VERSION}
 
     ## Spark only tags
     SPARK_TAG="${SPARK_VERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,7 @@ script:
 
 # Get latest set of Spark versions to build concurrently
 - |-
-  declare -a SPARK_VERSIONS=($(
+  SPARK_VERSIONS=($(
     curl -s https://archive.apache.org/dist/spark/ |
     grep -oE 'spark-[2]\.[[:digit:]]+\.[[:digit:]]/' |
     grep -oE '[2]\.[[:digit:]]+\.[[:digit:]]' |
@@ -76,6 +76,8 @@ script:
 # Iterate across each Spark version
 - |-
   for SPARK_VERSION in "${SPARK_VERSIONS[@]}"; do
+    echo Building Spark version - ${SPARK_VERSION}
+
     ## Spark only tags
     SPARK_TAG="${SPARK_VERSION}"
     SPARK_MAJMIN_TAG="${SPARK_VERSION:0:3}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,20 +66,16 @@ script:
 
 # Get latest set of Spark versions to build concurrently
 - |-
-  SPARK_VERSIONS_RAW=$(
+  declare -a SPARK_VERSIONS=($(
     curl -s https://archive.apache.org/dist/spark/ |
     grep -oE 'spark-[2]\.[[:digit:]]+\.[[:digit:]]/' |
     grep -oE '[2]\.[[:digit:]]+\.[[:digit:]]' |
     sort | uniq |
-    awk "NR % ${N} == ${IDX}")
-- echo Spark version\(s\) to build - ${SPARK_VERSIONS_RAW}
-- declare -a SPARK_VERSIONS=(${SPARK_VERSIONS_RAW})
+    awk "NR % ${N} == ${IDX}"))
 
 # Iterate across each Spark version
 - |-
   for SPARK_VERSION in "${SPARK_VERSIONS[@]}"; do
-    echo Building Spark version - ${SPARK_VERSION}
-
     ## Spark only tags
     SPARK_TAG="${SPARK_VERSION}"
     SPARK_MAJMIN_TAG="${SPARK_VERSION:0:3}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,16 +66,20 @@ script:
 
 # Get latest set of Spark versions to build concurrently
 - |-
-  SPARK_VERSIONS=$(
+  SPARK_VERSIONS_RAW=$(
     curl -s https://archive.apache.org/dist/spark/ |
     grep -oE 'spark-[2]\.[[:digit:]]+\.[[:digit:]]/' |
     grep -oE '[2]\.[[:digit:]]+\.[[:digit:]]' |
     sort | uniq |
     awk "NR % ${N} == ${IDX}")
+- echo "Spark version(s) to build: ${SPARK_VERSIONS_RAW}"
+- declare -a SPARK_VERSIONS=(${SPARK_VERSIONS_RAW})
 
 # Iterate across each Spark version
 - |-
   for SPARK_VERSION in "${SPARK_VERSIONS[@]}"; do
+    echo "Building Spark version: ${SPARK_VERSION}"
+
     ## Spark only tags
     SPARK_TAG="${SPARK_VERSION}"
     SPARK_MAJMIN_TAG="${SPARK_VERSION:0:3}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,13 +72,13 @@ script:
     grep -oE '[2]\.[[:digit:]]+\.[[:digit:]]' |
     sort | uniq |
     awk "NR % ${N} == ${IDX}")
-- echo Spark version\(s\) to build: ${SPARK_VERSIONS_RAW}
+- echo Spark version\(s\) to build ~ ${SPARK_VERSIONS_RAW}
 - declare -a SPARK_VERSIONS=(${SPARK_VERSIONS_RAW})
 
 # Iterate across each Spark version
 - |-
   for SPARK_VERSION in "${SPARK_VERSIONS[@]}"; do
-    echo Building Spark version: ${SPARK_VERSION}
+    echo Building Spark version ~ ${SPARK_VERSION}
 
     ## Spark only tags
     SPARK_TAG="${SPARK_VERSION}"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,118 +1,139 @@
 language: bash
 
+# Free Travis gives max 5 concurrent builds
 env:
   global:
   - IMAGE_NAME=${DOCKER_USERNAME}/spark
   - HADOOP_MAJMIN_VERSION=2.7
   - JAVA_MAJOR_VERSION=8
+  - N=5
 
+# Spark version is derived at runtime dynamically
 matrix:
   include:
   # Debian builds
   - services: docker
     env:
-    - SPARK_VERSION=2.4.0
     - DIST=debian
-    - LATEST=true
+    - IDX=1
   - services: docker
     env:
-    - SPARK_VERSION=2.3.2
     - DIST=debian
+    - IDX=2
   - services: docker
     env:
-    - SPARK_VERSION=2.2.3
     - DIST=debian
+    - IDX=3
   - services: docker
     env:
-    - SPARK_VERSION=2.1.3
     - DIST=debian
+    - IDX=4
   - services: docker
     env:
-    - SPARK_VERSION=2.0.2
     - DIST=debian
+    - IDX=0
   # Alpine builds
   - services: docker
     env:
-    - SPARK_VERSION=2.4.0
     - DIST=alpine
+    - IDX=1
   - services: docker
     env:
-    - SPARK_VERSION=2.3.2
     - DIST=alpine
+    - IDX=2
   - services: docker
     env:
-    - SPARK_VERSION=2.2.3
     - DIST=alpine
+    - IDX=3
   - services: docker
     env:
-    - SPARK_VERSION=2.1.3
     - DIST=alpine
+    - IDX=4
   - services: docker
     env:
-    - SPARK_VERSION=2.0.2
     - DIST=alpine
+    - IDX=0
   
 before_script:
 - docker login -u="${DOCKER_USERNAME}" -p="${DOCKER_PASSWORD}"
 
 script:
-# Docker tags to use (some are omitted since the version values are constant)
+# Define static tags for referencing
 - REF_TAG="ref"
 - REF_IMAGE="${IMAGE_NAME}:${REF_TAG}"
-
-## Spark only tags
-- SPARK_TAG="${SPARK_VERSION}"
-- SPARK_MAJMIN_TAG="${SPARK_VERSION:0:3}"
-
-## Spark + Java tags
 - JAVA_MAJOR_TAG="java-${JAVA_MAJOR_VERSION}"
-- SPARK_JAVA_MAJOR_TAG="${SPARK_TAG}_${JAVA_MAJOR_TAG}"
-- SPARK_MAJMIN_JAVA_MAJOR_TAG="${SPARK_MAJMIN_TAG}_${JAVA_MAJOR_TAG}"
-
-## Spark + Java + Dist tags
 - DIST_TAG="${DIST}"
-- SPARK_JAVA_MAJOR_DIST_TAG="${SPARK_TAG}_${JAVA_MAJOR_TAG}_${DIST_TAG}"
-- SPARK_MAJMIN_JAVA_MAJOR_DIST_TAG="${SPARK_MAJMIN_TAG}_${JAVA_MAJOR_TAG}_${DIST_TAG}"
 
-# Docker build
+# Get latest set of Spark versions to build concurrently
 - |-
-  docker build . -f Dockerfile-${DIST} \
-    --build-arg JAVA_MAJOR_VERSION="${JAVA_MAJOR_VERSION}" \
-    --build-arg SPARK_VERSION="${SPARK_VERSION}" \
-    --build-arg HADOOP_MAJMIN_VERSION="${HADOOP_MAJMIN_VERSION}" \
-    -t "${REF_IMAGE}"
+  SPARK_VERSIONS=$(
+    curl -s https://archive.apache.org/dist/spark/ |
+    grep -oE 'spark-[2]\.[[:digit:]]+\.[[:digit:]]/' |
+    grep -oE '[2]\.[[:digit:]]+\.[[:digit:]]' |
+    sort | uniq |
+    awk "NR % ${N} == ${IDX}")
 
-# Docker verification
+# Iterate across each Spark version
 - |-
-  docker run --rm -t ${REF_IMAGE} \
-    spark-submit --version | grep "${SPARK_VERSION}" > /dev/null
+  for SPARK_VERSION in "${SPARK_VERSIONS[@]}"; do
+    ## Spark only tags
+    SPARK_TAG="${SPARK_VERSION}"
+    SPARK_MAJMIN_TAG="${SPARK_VERSION:0:3}"
 
-# Docker re-tagging
-# Spark version is always unique across Nomad version, so all builds can tag and push independently
-- |-
-  if [ "${DIST} = debian" ]; then
-    # Non-dist tag is given to Debian
-    docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_TAG}"
-    docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_MAJMIN_TAG}"
-    docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_JAVA_MAJOR_TAG}"
-    docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_MAJMIN_JAVA_MAJOR_TAG}"
-  fi
-- docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_JAVA_MAJOR_DIST_TAG}"
-- docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_MAJMIN_JAVA_MAJOR_DIST_TAG}"
+    ## Spark + Java tags
+    SPARK_JAVA_MAJOR_TAG="${SPARK_TAG}_${JAVA_MAJOR_TAG}"
+    SPARK_MAJMIN_JAVA_MAJOR_TAG="${SPARK_MAJMIN_TAG}_${JAVA_MAJOR_TAG}"
 
-# Docker push to registry
-- |-
-  if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+    ## Spark + Dist tags
+    SPARK_DIST_TAG="${SPARK_TAG}_${DIST_TAG}"
+    SPARK_MAJMIN_DIST_TAG="${SPARK_MAJMIN_TAG}_${DIST_TAG}"
+
+    ## Spark + Java + Dist tags
+    SPARK_JAVA_MAJOR_DIST_TAG="${SPARK_TAG}_${JAVA_MAJOR_TAG}_${DIST_TAG}"
+    SPARK_MAJMIN_JAVA_MAJOR_DIST_TAG="${SPARK_MAJMIN_TAG}_${JAVA_MAJOR_TAG}_${DIST_TAG}"
+
+    # Docker build
+    docker build . -f Dockerfile-${DIST} \
+      --build-arg JAVA_MAJOR_VERSION="${JAVA_MAJOR_VERSION}" \
+      --build-arg SPARK_VERSION="${SPARK_VERSION}" \
+      --build-arg HADOOP_MAJMIN_VERSION="${HADOOP_MAJMIN_VERSION}" \
+      -t "${REF_IMAGE}"
+
+    # Docker verification
+    docker run --rm -t ${REF_IMAGE} \
+      spark-submit --version | grep "${SPARK_VERSION}" > /dev/null
+
+    # Docker re-tagging
+    # Spark version is always unique across Nomad version, so all builds can tag and push independently
     if [ "${DIST} = debian" ]; then
-      docker push "${IMAGE_NAME}:${SPARK_TAG}"
-      docker push "${IMAGE_NAME}:${SPARK_MAJMIN_TAG}"
-      docker push "${IMAGE_NAME}:${SPARK_JAVA_MAJOR_TAG}"
-      docker push "${IMAGE_NAME}:${SPARK_MAJMIN_JAVA_MAJOR_TAG}"
+      # Non-dist tag is given to Debian
+      docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_TAG}"
+      docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_MAJMIN_TAG}"
+      docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_JAVA_MAJOR_TAG}"
+      docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_MAJMIN_JAVA_MAJOR_TAG}"
     fi
 
-    docker push "${IMAGE_NAME}:${SPARK_JAVA_MAJOR_DIST_TAG}"
-    docker push "${IMAGE_NAME}:${SPARK_MAJMIN_JAVA_MAJOR_DIST_TAG}"
-  fi
+    # Common tags to all dists
+    docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_DIST_TAG}"
+    docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_MAJMIN_DIST_TAG}"
+    docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_JAVA_MAJOR_DIST_TAG}"
+    docker tag "${REF_IMAGE}" "${IMAGE_NAME}:${SPARK_MAJMIN_JAVA_MAJOR_DIST_TAG}"
+
+    # Docker push to registry
+    if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then
+      if [ "${DIST} = debian" ]; then
+        docker push "${IMAGE_NAME}:${SPARK_TAG}"
+        docker push "${IMAGE_NAME}:${SPARK_MAJMIN_TAG}"
+        docker push "${IMAGE_NAME}:${SPARK_JAVA_MAJOR_TAG}"
+        docker push "${IMAGE_NAME}:${SPARK_MAJMIN_JAVA_MAJOR_TAG}"
+      fi
+
+      docker push "${IMAGE_NAME}:${SPARK_DIST_TAG}"
+      docker push "${IMAGE_NAME}:${SPARK_MAJMIN_DIST_TAG}"
+      docker push "${IMAGE_NAME}:${SPARK_JAVA_MAJOR_DIST_TAG}"
+      docker push "${IMAGE_NAME}:${SPARK_MAJMIN_JAVA_MAJOR_DIST_TAG}"
+    fi
+  done
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -72,13 +72,13 @@ script:
     grep -oE '[2]\.[[:digit:]]+\.[[:digit:]]' |
     sort | uniq |
     awk "NR % ${N} == ${IDX}")
-- echo "Spark version(s) to build: ${SPARK_VERSIONS_RAW}"
+- echo Spark version\(s\) to build: ${SPARK_VERSIONS_RAW}
 - declare -a SPARK_VERSIONS=(${SPARK_VERSIONS_RAW})
 
 # Iterate across each Spark version
 - |-
   for SPARK_VERSION in "${SPARK_VERSIONS[@]}"; do
-    echo "Building Spark version: ${SPARK_VERSION}"
+    echo Building Spark version: ${SPARK_VERSION}
 
     ## Spark only tags
     SPARK_TAG="${SPARK_VERSION}"

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -20,7 +20,7 @@ RUN set -xeu; \
     export SPARK_DIR_PARENT="$(dirname "${SPARK_HOME}")"; \
     mkdir -p ${SPARK_DIR_PARENT}; \
     # Spark installation
-    wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/${SPARK_NAME}.tgz; \
+    wget -q https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/${SPARK_NAME}.tgz; \
     tar zxf ${SPARK_NAME}.tgz -C ${SPARK_DIR_PARENT}; \
     rm ${SPARK_NAME}.tgz; \
     ln -s ${SPARK_DIR} ${SPARK_HOME}; \

--- a/Dockerfile-debian
+++ b/Dockerfile-debian
@@ -24,7 +24,7 @@ RUN set -xeu; \
     apt-get install -y --no-install-recommends \
         wget; \
     # Spark installation
-    wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/${SPARK_NAME}.tgz; \
+    wget -q https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/${SPARK_NAME}.tgz; \
     tar zxf ${SPARK_NAME}.tgz -C ${SPARK_DIR_PARENT}; \
     rm ${SPARK_NAME}.tgz; \
     ln -s ${SPARK_DIR} ${SPARK_HOME}; \

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Spark Docker Builder
 
-Dockerfile setup to install various versions of Spark in a minimalist
-environment, for both slimmed Debian and Alpine.
+Dockerfile + Travis cron set-up to install all `2.y.z` versions of Spark in a
+minimalist environment, for both slimmed Debian and Alpine. This set-up is set
+to run weekly.
 
 The Java version `JAVA_MAJOR_VERSION` defaults to 8, while `SPARK_VERSION` build
 argument must be specified.


### PR DESCRIPTION
`SPARK_VERSION` is now derived from `curl`-ing the Spark archive releases page.